### PR TITLE
soup: check for /var/run/reboot-required

### DIFF
--- a/bin/soup
+++ b/bin/soup
@@ -127,6 +127,9 @@ apt-get dist-upgrade --assume-no | grep -A1000 "The following NEW packages will 
 # Do the actual upgrade
 apt-get -y dist-upgrade
 
+# Check again if the system requires a reboot
+test -e /var/run/reboot-required && REBOOT=yes
+
 # Final output
 echo $BANNER
 echo "All updates have been installed."


### PR DESCRIPTION
Sometimes the `REBOOT` variable is not set but the system requires a reboot anyway. I've added another check for the `/var/run/reboot-required` file created by the package manager.
