### PR TITLE
sostat: fix tput error when sending sostat email

### DIFF
--- a/bin/sostat
+++ b/bin/sostat
@@ -27,9 +27,12 @@ remove_ansi_escapes() {
 # Determine network interfaces for packet loss stats
 INTERFACES=`cat "/proc/net/dev" | egrep "(eth|bond|wlan|br|ath|bge|mon|fe|em|p[0-5]p)\w+" | awk '{print $1}' | cut -d':' -f1 | sort`
 # Text formatting
-underline=`tput smul`
-normal=`tput sgr0`
-#yellow=`tput setaf 3`
+if [ -t 1 ];then
+	underline=`tput smul`
+	normal=`tput sgr0`
+else
+	:
+fi
 # Begin output
 header "Service Status"
 service nsm status 2>&1 | remove_ansi_escapes


### PR DESCRIPTION
Fixes "tput: No value for $TERM and no -T specified" error displayed at the top of sostat (if receiving sostat email via latest updates, running email setup, and using latest /usr/bin/sostat).  

This error arises due to the fact that cron has no terminal type, thus we receive the error.

Ref:http://unix.stackexchange.com/questions/208982/tput-no-value-for-term-and-no-t-specified

Thanks,
Wes
