### PR TITLE
output when current monitoring interval has not completed

### DIFF
--- a/bin/sostat-interface-delta
+++ b/bin/sostat-interface-delta
@@ -7,5 +7,9 @@ grep -v "^#" /etc/nsm/sensortab |awk '{print $4}' |while read SENSOR; do
                 RX1=`head -1 $FILE`
                 RX2=`tail -1 $FILE`
                 expr $RX2 - $RX1
-        fi
+        else
+		echo "Stats not yet available."
+		echo
+		echo "Please wait until the current monitoring interval has completed."
+	fi
 done


### PR DESCRIPTION
Currently, if sostat is run before an initial (packet count) monitoring interval has completed (on a sensor/standalone), there is no output in sostat.

Ex. 
"=========================================================================
Packets received during last monitoring interval (600 seconds)
========================================================================="
[NO OUTPUT HERE]

This adds the following to /usr/bin/sostat-interface-delta if stats are not yet available:

Ex. 

"=========================================================================
Packets received during last monitoring interval (600 seconds)
========================================================================="
Stats not yet available.

Please wait until the current monitoring interval has completed.

Thanks,
Wes
