### PR TITLE
Sostat cleanup output: Suricata output when no packet drops received and sostat-interface formatting 

### DIFF
--- a/bin/sostat
+++ b/bin/sostat
@@ -112,8 +112,15 @@ if [ -d /nsm/sensor_data ]; then
 	if [ "$ENGINE" = "suricata" ]; then
         for i in /nsm/sensor_data/*/stats.log; do
                 echo "$i"
-                tail -n 50 "$i" | grep -e "Date: " -e "drop"
-                echo
+                if [ $( tail -n 50 $i | grep -c drop $i) -ne 0 ]; then
+			echo
+			tail -n 50 "$i" | grep -e "Date: " -e "drop"
+			echo
+		else
+			echo
+			echo "No packet drops reported."
+			echo
+		fi
         done
         else
 		for i in /nsm/sensor_data/*/snort-*.stats; do
@@ -125,7 +132,6 @@ if [ -d /nsm/sensor_data ]; then
 			fi
 		done
 	fi
-	echo
 	echo "-------------------------------------------------------------------------"
 	echo
         TMP=`mktemp`

--- a/bin/sostat-interface-delta
+++ b/bin/sostat-interface-delta
@@ -3,13 +3,18 @@
 grep -v "^#" /etc/nsm/sensortab |awk '{print $4}' |while read SENSOR; do
         FILE="/var/log/nsm/$SENSOR-packets.log"
         if [ -f $FILE ]; then
-                echo -n "$SENSOR: "
+                echo
+		echo -n "$SENSOR: "
                 RX1=`head -1 $FILE`
                 RX2=`tail -1 $FILE`
                 expr $RX2 - $RX1
         else
-		echo "Stats not yet available."
+		echo
+		echo
+		echo "Stats not yet available for $SENSOR."
 		echo
 		echo "Please wait until the current monitoring interval has completed."
+		echo
+		echo
 	fi
 done


### PR DESCRIPTION
Modifies sostat to include output for Suricata when no packet drops are received.

Modifies formatting in sostat-interface-delta for "Packets received during monitoring interval..."

Thanks,
Wes
