### PR TITLE
Fix redirect to file issue

### DIFF
--- a/bin/sostat
+++ b/bin/sostat
@@ -11,6 +11,9 @@
 # Determine if we're running Snort or Suricata
 source /etc/nsm/securityonion.conf
 
+# make sure if statements using wildcards for filenames don't equal true when no files exist
+shopt -s nullglob
+
 # Define a banner to separate sections
 banner="========================================================================="
 

--- a/bin/sostat
+++ b/bin/sostat
@@ -215,7 +215,7 @@ if [ -f /var/log/apt/history.log ]; then
 	tail /var/log/apt/history.log
 fi
 
-if (!(/usr/lib/update-notifier/apt-check --human-readable | grep -c '0') > 1); then
+if [ $(/usr/lib/update-notifier/apt-check --human-readable | grep -c '0') -ne 2 ]; then
         echo
         header "Available updates"
         /usr/lib/update-notifier/apt-check --human-readable


### PR DESCRIPTION
Instead of '>' being used as a comparator, it was being used as a redirector to a file named '1'.
