### PR TITLE
Remove redundant source call

### DIFF
--- a/bin/sostat
+++ b/bin/sostat
@@ -8,8 +8,12 @@
 # Stephane Chazelas
 # Shane Castle
 
-# Determine if we're running Snort or Suricata
-source /etc/nsm/securityonion.conf
+# Import settings file
+if [ -f /etc/nsm/securityonion.conf ]; then
+   source /etc/nsm/securityonion.conf
+else
+   echo "Missing /etc/nsm/securityonion.conf file!" && exit 1
+fi
 
 # Define a banner to separate sections
 banner="========================================================================="
@@ -223,7 +227,7 @@ if (!(/usr/lib/update-notifier/apt-check --human-readable | grep -c '0') > 1); t
         echo "Run 'sudo soup' to install the latest updates."
 fi
 
-if [ -f /etc/nsm/securityonion.conf ] && source /etc/nsm/securityonion.conf && [ "$ELSA" = "YES" ]; then
+if [ "$ELSA" = "YES" ]; then
         echo
         header "ELSA"
 	echo "Syslog-ng"


### PR DESCRIPTION
At the top of the script is a call to
'source /etc/nsm/securityonion.conf' however, later in the script
when there's a check if ELSA is defined, another call to source
/etc/nsm/securityonion.conf is done (along with check to see if the
file exists first).  I simply moved the file check code up to the top
of the script, removed the redundant source call,  and simplified the
if statement that checks if ELSA is defined.
