### PR TITLE
Enable nullglobs to prevent string literal bug in various for loops

### DIFF
--- a/bin/sostat
+++ b/bin/sostat
@@ -11,6 +11,9 @@
 # Determine if we're running Snort or Suricata
 source /etc/nsm/securityonion.conf
 
+#enable nullglobs to prevent file globs from becomming string literals
+shopt -s nullglob
+
 # Define a banner to separate sections
 banner="========================================================================="
 


### PR DESCRIPTION
Take this code as an example:

for i in /nsm/sensor_data/*/stats.log; do
        echo "$i"
        if [ $( tail -n 50 $i | grep -c drop ) -ne 0 ]; then

If there are no files that match '/nsm/sensor_data/_/status.log', the
non-intuitive default setting in shell scripts is to assign the literal
'/nsm/sensor_data/_/status.log' to $i.  This then breaks the following if
statement because tail is being passed a filename with a wildcard in it.
