### PR TITLE
get only last occurence of rule-update

### DIFF
--- a/bin/sostat
+++ b/bin/sostat
@@ -67,7 +67,9 @@ if [ -f /var/log/nsm/pulledpork.log ]; then
 	echo
 	header "IDS Rules Update"
 	date=$(date +'%a %b %_d')
-	tail -n 1000 /var/log/nsm/pulledpork.log |
+	tac /var/log/nsm/pulledpork.log |
+	  grep 'UTC' -m1 -B 1000 |
+	  tac |
 	  sed "/^$date/,\$!d;/./!d;/An error occurred: WARNING: /d" |
 	  remove_ansi_escapes
 fi


### PR DESCRIPTION
This should modify sostat to get only the output of the last run of rule-update from /var/log/nsm/pulledpork.log.  

Related to: https://github.com/Security-Onion-Solutions/securityonion-rule-update/pull/4.
