### PR TITLE
Fix 'Argument list too long' error and optimize the ls command

### DIFF
--- a/bin/sostat
+++ b/bin/sostat
@@ -354,7 +354,7 @@ if [ "$ELSA" = "YES" ]; then
         nc -4 -vz localhost 9306 2>&1
         echo
         echo "ELSA Buffers in Queue:"
-        ls -alt /nsm/elsa/data/elsa/tmp/buffers/* | wc -l
+        ls -al /nsm/elsa/data/elsa/tmp/buffers/ | wc -l
 	echo "If this number is consistently higher than 20, please see:"
 	echo "https://github.com/Security-Onion-Solutions/security-onion/wiki/FAQ#why-does-sostat-show-a-high-number-of-elsa-buffers-in-queue"
         echo


### PR DESCRIPTION
Using the asterisk here causes it to be expanded by the shell.  Since
there is an upper limit of files that ls can process, if the buffer
folder gets too large, this will incorrectly return 0 buffers after it
silently errors out.  By removing the asterisk, ls will perform like it
should.

I also removed the t argument from ls.  No need to sort by time when
doing a file count.