### PR TITLE
provide PF_RING loss as percentage

### DIFF
--- a/bin/sostat
+++ b/bin/sostat
@@ -182,10 +182,14 @@ if [ -d /nsm/sensor_data ] && [ $NUM_INTERFACES -gt 0 ]; then
 		echo "${underline}pf_ring${normal}:"
 		for i in /proc/net/pf_ring/*-* ; do
 			echo
-			#echo $i
-			grep "Appl. Name" $i
-			grep "Tot Packets" $i
-			grep "Tot Pkt Lost" $i
+			APP_NAME=`grep "Appl. Name" $i | awk '{print $4}'`
+                        PF_TOT_IN=`grep "Tot Packets" $i | awk '{print $4}'`
+                        PF_TOT_LOST=`grep "Tot Pkt Lost" $i | awk '{print $5}'`
+			PF_PERCENT_LOST=$(echo "scale=2 ; $PF_TOT_LOST * 10/$PF_TOT_IN * 10" | bc)
+                        echo "Appl. Name: $APP_NAME"
+			echo "Tot Packets: $PF_TOT_IN"
+			echo "Tot Pkt Lost: $PF_TOT_LOST"
+			echo "Loss as a percentage: $PF_PERCENT_LOST"
 			echo
 		done
 	fi


### PR DESCRIPTION
Add representation of packet loss as a percentage:

Ex.
````
pf_ring:

Appl. Name: bro-ens34
Tot Packets: 111
Tot Pkt Lost: 0
Loss as a percentage: 0


Appl. Name: snort-cluster-52-socket-0
Tot Packets: 111
Tot Pkt Lost: 0
Loss as a percentage: 0
````